### PR TITLE
add sqlite to docker file

### DIFF
--- a/base-fullbuild/Dockerfile
+++ b/base-fullbuild/Dockerfile
@@ -30,6 +30,7 @@ RUN <<EOF
         openssl1.1-compat \
         postgresql-client \
         sshfs \
+        sqlite \
         tzdata
 EOF
 


### PR DESCRIPTION
When using the option to backup sqlite databases with the `image: modem7/borgmatic-docker:dockercli` I got an error 
`/bin/sh: sqlite3: not found`

In the dockerfile I see that sqlite is not added. This should add it.
Tested it locally, and the error is gone.