### PR TITLE
Update Alpine package libacl to acl-libs

### DIFF
--- a/base-fullbuild/Dockerfile
+++ b/base-fullbuild/Dockerfile
@@ -47,7 +47,7 @@ RUN <<EOF
         curl                \
         findmnt             \
         fuse                \
-        libacl              \
+        acl-libs            \
         libxxhash           \
         logrotate           \
         lz4-libs            \


### PR DESCRIPTION
Was updated in https://gitlab.alpinelinux.org/alpine/aports/-/commit/0824e5bc4c0d1fb9aac2f133a4c0a92f1f0bb5b4. 

Resolves #159.

I haven't tested this other than to ensure it builds.