### PR TITLE
Fix Drone tags file: use comma-separated format

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,8 +14,7 @@ steps:
   commands:
     - borgmatic_ver=$(grep 'borgmatic' requirements.txt | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
     - borg_ver=$(grep 'borgbackup' requirements.txt | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
-    - echo "latest" > .tags
-    - echo "$${borgmatic_ver}-$${borg_ver}" >> .tags
+    - printf "latest,%s-%s" "$${borgmatic_ver}" "$${borg_ver}" > .tags
     - echo "Tags to publish:" && cat .tags
 
 - name: FullBuild

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2026-06-27 (continued 4)
+
+### Fixed
+
+- `.drone.yml`: Drone tags file now written as a single comma-separated line (`latest,2.1.6-1.4.4`) rather than one tag per line. `thegeeklab/drone-docker-buildx` treated the entire file content as one string, causing an invalid tag error (`latest\n2.1.6-1.4.4`).
+
 ## 2026-06-27 (continued 3)
 
 ### Added


### PR DESCRIPTION
## Summary

- The `thegeeklab/drone-docker-buildx` plugin treats the entire `tags_file` content as a single string rather than splitting on newlines. The previous format (one tag per line) produced an invalid tag `latest\n2.1.6-1.4.4` causing a build error.
- Switch to a single comma-separated line: `latest,2.1.6-1.4.4`.

## Test plan

- [x] Drone pipeline builds and pushes both `latest` and version-pinned tag successfully