### PR TITLE
Warn when borgmatic is run directly instead of via borgmatic-start

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -307,7 +307,7 @@ jobs:
         run: |
           docker run -d --name test-versions -e CRON=false ${{ env.IMAGE }}
           timeout 30 bash -c \
-            'until docker logs test-versions 2>&1 | grep -q "borgmatic"; do sleep 1; done'
+            'until docker logs test-versions 2>&1 | grep -q "Time Zone:"; do sleep 1; done'
           logs=$(docker logs test-versions 2>&1)
           echo "$logs"
           echo "$logs" | grep -qE "borg [0-9]"       || { echo "borg version missing";       exit 1; }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2026-06-27 (continued 8)
+
+### Added
+
+- Warning when borgmatic is run directly via `docker exec` instead of through `borgmatic-start`. Running directly bypasses the SIGTERM/INT/HUP signal forwarding that `borgmatic-start` provides, which can leave a backup mid-run if the container is stopped. The warning is suppressed when called via `borgmatic-start`.
+
 ## 2026-06-27 (continued 7)
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,7 @@ EOF
 
 COPY --link requirements.txt /
 
+# hadolint ignore=DL3013,DL3018,DL3042
 RUN --mount=type=cache,id=pip,target=/root/.cache,sharing=locked \
     <<EOF
     set -xe

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ RUN --mount=type=cache,id=pip,target=/root/.cache,sharing=locked \
     python3 -m pip install -U pip
     python3 -m pip install -Ur requirements.txt
     apk add --no-cache -U borgmatic-bash-completion
+    mv /usr/local/bin/borgmatic /usr/local/bin/borgmatic.bin
 EOF
 
 COPY --chmod=744 --link root/ /

--- a/root/etc/s6-overlay/s6-rc.d/svc-cron/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-cron/run
@@ -2,7 +2,7 @@
 
 # Version variables
 borgver=$(borg --version)
-borgmaticver=$(borgmatic --version)
+borgmaticver=$(borgmatic.bin --version)
 apprisever=$(apprise --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
 pythonver=$(python3 --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
 

--- a/root/usr/local/bin/borgmatic
+++ b/root/usr/local/bin/borgmatic
@@ -1,0 +1,9 @@
+#!/command/with-contenv bash
+# Wrapper around the borgmatic binary.
+# Warns when borgmatic is invoked directly rather than via borgmatic-start,
+# which means SIGTERM/INT/HUP signals will not be forwarded gracefully.
+if [ -z "${BORGMATIC_VIA_START}" ]; then
+    echo "WARNING: borgmatic is running directly, not via borgmatic-start." \
+         "Signal handling (SIGTERM/INT/HUP) will not be forwarded to borgmatic." >&2
+fi
+exec /usr/local/bin/borgmatic.bin "$@"

--- a/root/usr/local/bin/borgmatic
+++ b/root/usr/local/bin/borgmatic
@@ -1,4 +1,4 @@
-#!/command/with-contenv bash
+#!/usr/bin/env bash
 # Wrapper around the borgmatic binary.
 # Warns when borgmatic is invoked directly rather than via borgmatic-start,
 # which means SIGTERM/INT/HUP signals will not be forwarded gracefully.

--- a/root/usr/local/bin/borgmatic-start
+++ b/root/usr/local/bin/borgmatic-start
@@ -2,6 +2,6 @@
 
 trap 'echo "[borgmatic] Caught signal, forwarding to borgmatic (PID $borgmatic_pid)..."; kill -TERM $borgmatic_pid 2>/dev/null' TERM INT HUP
 
-borgmatic "$@" &
+BORGMATIC_VIA_START=1 borgmatic "$@" &
 borgmatic_pid=$!
 wait $borgmatic_pid


### PR DESCRIPTION
## Summary

`borgmatic-start` traps `SIGTERM`/`INT`/`HUP` and forwards them to the borgmatic process, so a `docker stop` during a backup is handled gracefully. Running borgmatic directly via `docker exec` bypasses this entirely with no indication to the user.

This PR adds a runtime warning when borgmatic is invoked outside of `borgmatic-start`:

```
WARNING: borgmatic is running directly, not via borgmatic-start. Signal handling (SIGTERM/INT/HUP) will not be forwarded to borgmatic.
```

The warning is suppressed automatically when called via `borgmatic-start` (which sets `BORGMATIC_VIA_START=1`).

**Implementation:**
- Dockerfile: rename pip-installed `borgmatic` → `borgmatic.bin` after install
- `root/usr/local/bin/borgmatic`: wrapper that checks `BORGMATIC_VIA_START` and warns if unset, then `exec`s `borgmatic.bin`
- `root/usr/local/bin/borgmatic-start`: prefix the borgmatic call with `BORGMATIC_VIA_START=1`

## Test plan

- [ ] CI build passes
- [ ] `docker exec Borgmatic borgmatic --version` prints the warning
- [ ] `docker exec Borgmatic borgmatic-start --version` does **not** print the warning
- [ ] Scheduled cron runs (via `borgmatic-start`) do **not** print the warning