### PR TITLE
Simplify borgmatic wrapper: silent passthrough, no warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## 2026-06-27 (continued 8)
 
-### Added
+### Changed
 
-- Warning when borgmatic is run directly via `docker exec` instead of through `borgmatic-start`. Running directly bypasses the SIGTERM/INT/HUP signal forwarding that `borgmatic-start` provides, which can leave a backup mid-run if the container is stopped. The warning is suppressed when called via `borgmatic-start`.
+- `borgmatic` is now a thin wrapper around `borgmatic.bin` (the pip-installed binary), allowing the entrypoint to be intercepted cleanly without any behaviour change for users.
 
 ## 2026-06-27 (continued 7)
 

--- a/root/etc/s6-overlay/s6-rc.d/svc-cron/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-cron/run
@@ -2,7 +2,7 @@
 
 # Version variables
 borgver=$(borg --version)
-borgmaticver=$(borgmatic.bin --version)
+borgmaticver=$(borgmatic --version)
 apprisever=$(apprise --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
 pythonver=$(python3 --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
 

--- a/root/usr/local/bin/borgmatic
+++ b/root/usr/local/bin/borgmatic
@@ -1,9 +1,2 @@
 #!/usr/bin/env bash
-# Wrapper around the borgmatic binary.
-# Warns when borgmatic is invoked directly rather than via borgmatic-start,
-# which means SIGTERM/INT/HUP signals will not be forwarded gracefully.
-if [ -z "${BORGMATIC_VIA_START}" ]; then
-    echo "WARNING: borgmatic is running directly, not via borgmatic-start." \
-         "Signal handling (SIGTERM/INT/HUP) will not be forwarded to borgmatic." >&2
-fi
 exec /usr/local/bin/borgmatic.bin "$@"

--- a/root/usr/local/bin/borgmatic-start
+++ b/root/usr/local/bin/borgmatic-start
@@ -2,6 +2,6 @@
 
 trap 'echo "[borgmatic] Caught signal, forwarding to borgmatic (PID $borgmatic_pid)..."; kill -TERM $borgmatic_pid 2>/dev/null' TERM INT HUP
 
-BORGMATIC_VIA_START=1 borgmatic "$@" &
+borgmatic "$@" &
 borgmatic_pid=$!
 wait $borgmatic_pid


### PR DESCRIPTION
## Summary

The warning added in #240 turns out to be unnecessary. Users calling `borgmatic` directly are now transparently routed through the wrapper to `borgmatic.bin` — no behaviour change from their perspective.

The cron detection warning in `svc-cron/run` already covers the important case (someone putting `borgmatic` directly in their cron schedule instead of `borgmatic-start`).

Changes:
- `borgmatic` wrapper: remove warning, silent `exec borgmatic.bin "$@"` only
- `borgmatic-start`: revert `BORGMATIC_VIA_START=1` prefix (no longer needed)
- `svc-cron/run`: revert `borgmatic.bin --version` back to `borgmatic --version`

## Test plan

- [ ] CI passes
- [ ] `docker exec Borgmatic borgmatic --version` works silently with no warning
- [ ] `docker exec Borgmatic borgmatic-start --version` works as before