### PR TITLE
Add optional KeePassXC credential support via pykeepass shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-- KeePassXC credential support via opt-in init script (`data/borgscripts/init-keepassxc-cli.sh`). Installs a shim at `/usr/local/bin/keepassxc-cli` backed by `pykeepass` (file-based) and `secretstorage`/`jeepney` (host D-Bus secret service). No image bloat — ~2 MB vs ~150 MB for the Alpine Qt6 package. See `data/borgscripts/KEEPASSXC-CLI.md` for setup.
+- KeePassXC credential support via opt-in init script (`data/borgscripts/init-keepassxc-cli.sh`). Installs a `pykeepass`-backed shim at `/usr/local/bin/keepassxc-cli` that implements the exact CLI interface borgmatic calls — no image bloat (~2 MB vs ~150 MB for the Alpine Qt6 package). See `data/borgscripts/KEEPASSXC-CLI.md` for setup.
 
 ## 2026-06-27 (continued 8)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-- KeePassXC credential support via opt-in init script (`data/borgscripts/init-keepassxc-cli.sh`). Installs a `pykeepass`-backed shim at `/usr/local/bin/keepassxc-cli` that implements the exact CLI interface borgmatic calls — no image bloat (~2 MB vs ~150 MB for the Alpine Qt6 package). See `data/borgscripts/KEEPASSXC-CLI.md` for setup.
+- KeePassXC credential support via opt-in init script (`data/borgscripts/init-keepassxc-cli.sh`). Installs a shim at `/usr/local/bin/keepassxc-cli` backed by `pykeepass` (file-based) and `secretstorage`/`jeepney` (host D-Bus secret service). No image bloat — ~2 MB vs ~150 MB for the Alpine Qt6 package. See `data/borgscripts/KEEPASSXC-CLI.md` for setup.
 
 ## 2026-06-27 (continued 8)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2026-06-27 (continued 9)
+
+### Added
+
+- KeePassXC credential support via opt-in init script (`data/borgscripts/init-keepassxc-cli.sh`). Installs a `pykeepass`-backed shim at `/usr/local/bin/keepassxc-cli` that implements the exact CLI interface borgmatic calls — no image bloat (~2 MB vs ~150 MB for the Alpine Qt6 package). See `data/borgscripts/KEEPASSXC-CLI.md` for setup.
+
 ## 2026-06-27 (continued 8)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -606,11 +606,11 @@ commands:
 
 ## KeePassXC credential support
 
-borgmatic supports retrieving secrets from a KeePass database via the `{credential keepassxc ...}` syntax. Because Alpine's `keepassxc` package pulls in the full Qt6 GUI stack (~150 MB), this image ships an **opt-in shim** instead — a lightweight Python script backed by `pykeepass` and `secretstorage` that implements the exact CLI interface borgmatic expects.
+borgmatic supports retrieving secrets from a KeePass database via the `{credential keepassxc ...}` syntax. Because Alpine's `keepassxc` package pulls in the full Qt6 GUI stack (~150 MB), this image ships an **opt-in shim** instead — a lightweight Python script backed by `pykeepass` that implements the exact CLI interface borgmatic expects.
 
-Two backends are supported:
+### Quick setup
 
-**File-based** — reads directly from a `.kdbx` file mounted into the container:
+Mount the init script at startup:
 
 ```yaml
 services:
@@ -621,29 +621,15 @@ services:
       - /path/to/your/passwords.keyx:/run/secrets/keepass.keyx:ro  # optional key file
 ```
 
+Configure borgmatic:
+
 ```yaml
 keepassxc:
     database: /etc/borgmatic/passwords.kdbx
-    ask_for_password: false
+    ask_for_password: false   # required for unattended/cron backups
     key_file: /run/secrets/keepass.keyx
 
 encryption_passphrase: "{credential keepassxc /etc/borgmatic/passwords.kdbx MyBorgEntry}"
-```
-
-**Secret service** — connects to KeePassXC running on the host via a mounted D-Bus session socket:
-
-```yaml
-services:
-  borgmatic:
-    volumes:
-      - ./data/borgscripts/init-keepassxc-cli.sh:/custom-cont-init.d/init-keepassxc-cli.sh:ro
-      - /run/user/1000/bus:/run/dbus/session_bus_socket:ro
-    environment:
-      - DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/session_bus_socket
-```
-
-```yaml
-encryption_passphrase: "{credential keepassxc secret-service MyBorgEntry}"
 ```
 
 See [`data/borgscripts/KEEPASSXC-CLI.md`](data/borgscripts/KEEPASSXC-CLI.md) for full setup instructions, security notes, and database hook examples.

--- a/README.md
+++ b/README.md
@@ -606,11 +606,11 @@ commands:
 
 ## KeePassXC credential support
 
-borgmatic supports retrieving secrets from a KeePass database via the `{credential keepassxc ...}` syntax. Because Alpine's `keepassxc` package pulls in the full Qt6 GUI stack (~150 MB), this image ships an **opt-in shim** instead — a lightweight Python script backed by `pykeepass` that implements the exact CLI interface borgmatic expects.
+borgmatic supports retrieving secrets from a KeePass database via the `{credential keepassxc ...}` syntax. Because Alpine's `keepassxc` package pulls in the full Qt6 GUI stack (~150 MB), this image ships an **opt-in shim** instead — a lightweight Python script backed by `pykeepass` and `secretstorage` that implements the exact CLI interface borgmatic expects.
 
-### Quick setup
+Two backends are supported:
 
-Mount the init script at startup:
+**File-based** — reads directly from a `.kdbx` file mounted into the container:
 
 ```yaml
 services:
@@ -621,15 +621,29 @@ services:
       - /path/to/your/passwords.keyx:/run/secrets/keepass.keyx:ro  # optional key file
 ```
 
-Configure borgmatic:
-
 ```yaml
 keepassxc:
     database: /etc/borgmatic/passwords.kdbx
-    ask_for_password: false   # required for unattended/cron backups
+    ask_for_password: false
     key_file: /run/secrets/keepass.keyx
 
 encryption_passphrase: "{credential keepassxc /etc/borgmatic/passwords.kdbx MyBorgEntry}"
+```
+
+**Secret service** — connects to KeePassXC running on the host via a mounted D-Bus session socket:
+
+```yaml
+services:
+  borgmatic:
+    volumes:
+      - ./data/borgscripts/init-keepassxc-cli.sh:/custom-cont-init.d/init-keepassxc-cli.sh:ro
+      - /run/user/1000/bus:/run/dbus/session_bus_socket:ro
+    environment:
+      - DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/session_bus_socket
+```
+
+```yaml
+encryption_passphrase: "{credential keepassxc secret-service MyBorgEntry}"
 ```
 
 See [`data/borgscripts/KEEPASSXC-CLI.md`](data/borgscripts/KEEPASSXC-CLI.md) for full setup instructions, security notes, and database hook examples.

--- a/README.md
+++ b/README.md
@@ -604,6 +604,38 @@ commands:
 
 ---
 
+## KeePassXC credential support
+
+borgmatic supports retrieving secrets from a KeePass database via the `{credential keepassxc ...}` syntax. Because Alpine's `keepassxc` package pulls in the full Qt6 GUI stack (~150 MB), this image ships an **opt-in shim** instead — a lightweight Python script backed by `pykeepass` that implements the exact CLI interface borgmatic expects.
+
+### Quick setup
+
+Mount the init script at startup:
+
+```yaml
+services:
+  borgmatic:
+    volumes:
+      - ./data/borgscripts/init-keepassxc-cli.sh:/custom-cont-init.d/init-keepassxc-cli.sh:ro
+      - /path/to/your/passwords.kdbx:/etc/borgmatic/passwords.kdbx:ro
+      - /path/to/your/passwords.keyx:/run/secrets/keepass.keyx:ro  # optional key file
+```
+
+Configure borgmatic:
+
+```yaml
+keepassxc:
+    database: /etc/borgmatic/passwords.kdbx
+    ask_for_password: false   # required for unattended/cron backups
+    key_file: /run/secrets/keepass.keyx
+
+encryption_passphrase: "{credential keepassxc /etc/borgmatic/passwords.kdbx MyBorgEntry}"
+```
+
+See [`data/borgscripts/KEEPASSXC-CLI.md`](data/borgscripts/KEEPASSXC-CLI.md) for full setup instructions, security notes, and database hook examples.
+
+---
+
 ## Native database backup (borgmatic)
 
 For PostgreSQL, MariaDB/MySQL, MongoDB, and SQLite, borgmatic has built-in support that dumps the database and includes the dump in the archive — no separate script needed. Example for PostgreSQL:

--- a/data/borgscripts/KEEPASSXC-CLI.md
+++ b/data/borgscripts/KEEPASSXC-CLI.md
@@ -1,0 +1,144 @@
+# KeePassXC credential support
+
+This image does not include `keepassxc-cli` by default because the only Alpine
+package available (`keepassxc`) pulls in the full Qt6 GUI stack — adding
+~150 MB to an image that is otherwise under 200 MB. That trade-off is not
+reasonable for users who never touch KeePass.
+
+Instead, this image ships a lightweight Python shim that replicates the exact
+CLI interface that borgmatic calls. You opt in by mounting a single init script
+at container startup. **No changes to borgmatic itself are needed.**
+
+---
+
+## How the shim works (note for borgmatic developers)
+
+borgmatic calls `keepassxc-cli` like this:
+
+```
+keepassxc-cli show --show-protected --attributes Password \
+    [--no-password] [--key-file /path/to/key] \
+    /path/to/database.kdbx "entry-title"
+```
+
+The shim at `/usr/local/bin/keepassxc-cli` accepts the same arguments and
+flags, uses [`pykeepass`](https://github.com/libkeepass/pykeepass) (a
+pure-Python KeePass 4 reader) to open the database, and prints the requested
+attribute to stdout — identical output to the real `keepassxc-cli`.
+
+Because the interface is identical, borgmatic does not need to know or care
+that it is talking to a Python script instead of the real binary. The
+`keepassxc_cli_command` config option can be left at its default
+(`keepassxc-cli`) since the shim is installed at the same path.
+
+Supported flags: `--show-protected`, `--attributes`/`-a`, `--no-password`,
+`--key-file`/`-k`, `--yubikey` (accepted silently — hardware tokens are not
+supported). Attribute lookup covers `Password`, `UserName`, `URL`, `Notes`,
+`Title`, and custom attributes. Group-path style entry names
+(`Group/Entry`) are supported.
+
+---
+
+## Setup
+
+### 1. Mount the init script
+
+Add a volume mount to your `docker-compose.yml`:
+
+```yaml
+services:
+  borgmatic:
+    volumes:
+      # ... your existing volumes ...
+      - ./data/borgscripts/init-keepassxc-cli.sh:/custom-cont-init.d/init-keepassxc-cli.sh:ro
+```
+
+At startup the script installs `pykeepass` (~2 MB, no system packages) and
+writes the `keepassxc-cli` shim to `/usr/local/bin/keepassxc-cli`.
+
+### 2. Mount your KeePass database (and key file, if used)
+
+```yaml
+    volumes:
+      - /path/to/your/passwords.kdbx:/etc/borgmatic/passwords.kdbx:ro
+      - /path/to/your/passwords.keyx:/run/secrets/keepass.keyx:ro  # optional
+```
+
+Keep the database and key file outside your backup source so they are not
+backed up to themselves.
+
+### 3. Configure borgmatic
+
+Add a `keepassxc:` block to your borgmatic config:
+
+```yaml
+keepassxc:
+    database: /etc/borgmatic/passwords.kdbx
+
+    # Set to false to use a key file instead of typing a password at startup.
+    # Required for unattended/scheduled backups.
+    ask_for_password: false
+
+    # Optional — omit if your database is password-protected only.
+    key_file: /run/secrets/keepass.keyx
+```
+
+Then reference credentials anywhere a password is expected:
+
+```yaml
+# Borg repository passphrase
+encryption_passphrase: "{credential keepassxc /etc/borgmatic/passwords.kdbx MyBorgEntry}"
+
+# Database hook credentials
+postgresql_databases:
+    - name: mydb
+      username: "{credential keepassxc /etc/borgmatic/passwords.kdbx PostgresUser}"
+      password: "{credential keepassxc /etc/borgmatic/passwords.kdbx PostgresPassword}"
+```
+
+The value in quotes (`MyBorgEntry`, `PostgresUser`, etc.) is the **title** of
+the entry inside your KeePass database.
+
+### 4. Verify at startup
+
+When the container starts you should see:
+
+```
+[init-keepassxc-cli] Installing pykeepass...
+[init-keepassxc-cli] Writing /usr/local/bin/keepassxc-cli shim...
+[init-keepassxc-cli] Done. keepassxc-cli shim is ready.
+```
+
+Run a manual check to confirm borgmatic can reach the database:
+
+```console
+docker exec -it borgmatic borgmatic config validate
+```
+
+---
+
+## Unattended backups and key files
+
+`keepassxc-cli` normally prompts for the database master password interactively,
+which breaks scheduled (cron) backups. Use a key file instead and set
+`ask_for_password: false` in your borgmatic config — the shim will open the
+database with the key file alone, no prompt.
+
+Store the key file outside your container (e.g. in a Docker secret or a
+host path not included in your backup source) and mount it read-only.
+
+---
+
+## Security notes
+
+- The `pykeepass` library reads the KeePass 4 (`.kdbx`) format entirely
+  in-process — the database is never sent anywhere.
+- The shim prints the requested attribute to stdout exactly as
+  `keepassxc-cli` does; borgmatic captures it in memory and never writes it
+  to disk.
+- `pykeepass` is installed at container startup rather than baked into the
+  image, so it is covered by your normal image rebuild/update cycle via
+  `docker compose pull`.
+- Pin the version if you need reproducible builds:
+  edit `init-keepassxc-cli.sh` and change
+  `pip install pykeepass` to `pip install pykeepass==<version>`.

--- a/data/borgscripts/KEEPASSXC-CLI.md
+++ b/data/borgscripts/KEEPASSXC-CLI.md
@@ -129,69 +129,23 @@ host path not included in your backup source) and mount it read-only.
 
 ---
 
-## Secret Service integration (host D-Bus)
+## Limitations
 
-borgmatic supports `{credential keepassxc secret-service <label>}` which
-retrieves credentials via the D-Bus Secret Service API — the same mechanism
-desktop apps use to talk to a running KeePassXC or GNOME Keyring instance.
+### Secret Service integration is not supported
 
-This works in Docker by mounting the **host's D-Bus session socket** into
-the container. The shim uses [`secretstorage`](https://github.com/mitya57/secretstorage)
-with [`jeepney`](https://jeepney.readthedocs.io/) (both pure Python, no system
-packages) to connect to it.
+borgmatic supports a `{credential keepassxc secret-service <key>}` syntax that
+retrieves credentials via the D-Bus Secret Service API — the mechanism desktop
+apps use to talk to a running KeePassXC or GNOME Keyring instance.
 
-### Requirements on the host
+This does **not** work in a headless Docker container. The Secret Service API
+requires a running D-Bus session bus and a Secret Service provider (KeePassXC
+GUI or `gnome-keyring-daemon`) — neither of which exist in a container, and
+providing them would pull in the full Qt6/GTK desktop stack that this shim
+exists to avoid.
 
-- KeePassXC running with **Secret Service integration enabled**
-  (Settings → Secret Service Integration → Enable)
-- The database unlocked before the borgmatic container starts
-
-### Volume mount
-
-The Secret Service API runs on the **session bus** (per-user), not the system
-bus. The session socket location depends on your system:
-
-| Init system | Typical path |
-|---|---|
-| systemd | `/run/user/1000/bus` (replace `1000` with your UID) |
-| Non-systemd | `/var/run/dbus/session_bus_socket` or check `$DBUS_SESSION_BUS_ADDRESS` |
-
-```yaml
-services:
-  borgmatic:
-    volumes:
-      - ./data/borgscripts/init-keepassxc-cli.sh:/custom-cont-init.d/init-keepassxc-cli.sh:ro
-      # Mount the host session bus socket — adjust path for your system
-      - /run/user/1000/bus:/run/dbus/session_bus_socket:ro
-    environment:
-      - DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/session_bus_socket
-```
-
-### borgmatic config
-
-```yaml
-encryption_passphrase: "{credential keepassxc secret-service MyBorgEntry}"
-```
-
-Where `MyBorgEntry` is the **label** of the item as it appears in KeePassXC's
-secret service (usually the entry title).
-
-### Verify
-
-```console
-docker exec -it borgmatic keepassxc-cli show --secret-service MyBorgEntry
-```
-
-Should print the password without prompting.
-
-### Notes
-
-- The container connects to KeePassXC running on the **host** — no KeePass
-  process runs inside the container itself.
-- If the collection is locked (KeePassXC database closed), the shim exits
-  with an error. Ensure KeePassXC is unlocked before backups run.
-- For fully unattended/scheduled backups the file-based approach with a key
-  file is simpler and has no dependency on a running desktop application.
+**For unattended Docker backups, use the key file approach** (`ask_for_password:
+false` + `key_file`). It requires no interactive prompt and no running desktop
+environment.
 
 ---
 

--- a/data/borgscripts/KEEPASSXC-CLI.md
+++ b/data/borgscripts/KEEPASSXC-CLI.md
@@ -129,28 +129,69 @@ host path not included in your backup source) and mount it read-only.
 
 ---
 
-## Limitations
+## Secret Service integration (host D-Bus)
 
-### Secret Service integration is not supported
+borgmatic supports `{credential keepassxc secret-service <label>}` which
+retrieves credentials via the D-Bus Secret Service API — the same mechanism
+desktop apps use to talk to a running KeePassXC or GNOME Keyring instance.
 
-borgmatic supports a `{credential keepassxc secret-service <key>}` syntax that
-retrieves credentials via the D-Bus Secret Service API (the same mechanism
-desktop apps use to talk to a running KeePassXC or GNOME Keyring instance).
+This works in Docker by mounting the **host's D-Bus session socket** into
+the container. The shim uses [`secretstorage`](https://github.com/mitya57/secretstorage)
+with [`jeepney`](https://jeepney.readthedocs.io/) (both pure Python, no system
+packages) to connect to it.
 
-This does **not** work in a headless Docker container. The Secret Service API
-requires:
+### Requirements on the host
 
-1. A running D-Bus session bus
-2. A Secret Service provider (KeePassXC GUI or `gnome-keyring-daemon`) exposing
-   credentials on that bus
+- KeePassXC running with **Secret Service integration enabled**
+  (Settings → Secret Service Integration → Enable)
+- The database unlocked before the borgmatic container starts
 
-Neither exists in a container by default, and providing them would pull in the
-full Qt6/GTK desktop stack — exactly the dependency weight this shim exists to
-avoid.
+### Volume mount
 
-**For unattended Docker backups, use the key file approach** (`ask_for_password:
-false` + `key_file`) instead of secret service. It requires no interactive
-prompt and no running desktop environment.
+The Secret Service API runs on the **session bus** (per-user), not the system
+bus. The session socket location depends on your system:
+
+| Init system | Typical path |
+|---|---|
+| systemd | `/run/user/1000/bus` (replace `1000` with your UID) |
+| Non-systemd | `/var/run/dbus/session_bus_socket` or check `$DBUS_SESSION_BUS_ADDRESS` |
+
+```yaml
+services:
+  borgmatic:
+    volumes:
+      - ./data/borgscripts/init-keepassxc-cli.sh:/custom-cont-init.d/init-keepassxc-cli.sh:ro
+      # Mount the host session bus socket — adjust path for your system
+      - /run/user/1000/bus:/run/dbus/session_bus_socket:ro
+    environment:
+      - DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/session_bus_socket
+```
+
+### borgmatic config
+
+```yaml
+encryption_passphrase: "{credential keepassxc secret-service MyBorgEntry}"
+```
+
+Where `MyBorgEntry` is the **label** of the item as it appears in KeePassXC's
+secret service (usually the entry title).
+
+### Verify
+
+```console
+docker exec -it borgmatic keepassxc-cli show --secret-service MyBorgEntry
+```
+
+Should print the password without prompting.
+
+### Notes
+
+- The container connects to KeePassXC running on the **host** — no KeePass
+  process runs inside the container itself.
+- If the collection is locked (KeePassXC database closed), the shim exits
+  with an error. Ensure KeePassXC is unlocked before backups run.
+- For fully unattended/scheduled backups the file-based approach with a key
+  file is simpler and has no dependency on a running desktop application.
 
 ---
 

--- a/data/borgscripts/KEEPASSXC-CLI.md
+++ b/data/borgscripts/KEEPASSXC-CLI.md
@@ -129,6 +129,31 @@ host path not included in your backup source) and mount it read-only.
 
 ---
 
+## Limitations
+
+### Secret Service integration is not supported
+
+borgmatic supports a `{credential keepassxc secret-service <key>}` syntax that
+retrieves credentials via the D-Bus Secret Service API (the same mechanism
+desktop apps use to talk to a running KeePassXC or GNOME Keyring instance).
+
+This does **not** work in a headless Docker container. The Secret Service API
+requires:
+
+1. A running D-Bus session bus
+2. A Secret Service provider (KeePassXC GUI or `gnome-keyring-daemon`) exposing
+   credentials on that bus
+
+Neither exists in a container by default, and providing them would pull in the
+full Qt6/GTK desktop stack — exactly the dependency weight this shim exists to
+avoid.
+
+**For unattended Docker backups, use the key file approach** (`ask_for_password:
+false` + `key_file`) instead of secret service. It requires no interactive
+prompt and no running desktop environment.
+
+---
+
 ## Security notes
 
 - The `pykeepass` library reads the KeePass 4 (`.kdbx`) format entirely

--- a/data/borgscripts/init-keepassxc-cli.sh
+++ b/data/borgscripts/init-keepassxc-cli.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Optional custom init script — mount at /custom-cont-init.d/init-keepassxc-cli.sh
+#
+# Installs a lightweight keepassxc-cli shim using pykeepass (pure Python,
+# no Qt/GUI dependencies) so borgmatic can retrieve credentials from a
+# KeePass database.
+#
+# Usage in borgmatic config:
+#   keepassxc:
+#     keepassxc_cli_command: /usr/local/bin/keepassxc-cli
+#     database: /path/to/passwords.kdbx
+#     ask_for_password: false       # use key_file instead
+#     key_file: /run/secrets/keepass.keyx   # optional
+#
+# Then reference credentials in your config:
+#   encryption_passphrase: "{credential keepassxc /path/to/passwords.kdbx MyEntry}"
+
+set -e
+
+echo "[init-keepassxc-cli] Installing pykeepass..."
+pip install --quiet --no-cache-dir pykeepass
+
+echo "[init-keepassxc-cli] Writing /usr/local/bin/keepassxc-cli shim..."
+cat > /usr/local/bin/keepassxc-cli << 'SHIM'
+#!/usr/bin/env python3
+"""
+Minimal keepassxc-cli shim backed by pykeepass.
+Implements the subset of keepassxc-cli that borgmatic calls:
+  keepassxc-cli show --show-protected --attributes <attr>
+                     [--no-password] [--key-file <file>]
+                     <database> <entry>
+"""
+import argparse
+import sys
+
+try:
+    from pykeepass import PyKeePass
+    from pykeepass.exceptions import CredentialsError
+except ImportError:
+    print("pykeepass is not installed", file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command")                          # 'show'
+    parser.add_argument("--show-protected", action="store_true")
+    parser.add_argument("--attributes", "-a", default="Password")
+    parser.add_argument("--no-password", action="store_true")
+    parser.add_argument("--key-file", "-k", default=None)
+    parser.add_argument("--yubikey", default=None)          # unsupported, accepted silently
+    parser.add_argument("database")
+    parser.add_argument("entry")
+    args = parser.parse_args()
+
+    if args.command != "show":
+        print(f"Unsupported command: {args.command}", file=sys.stderr)
+        sys.exit(1)
+
+    password = None if args.no_password else input("Enter password to unlock database: ")
+
+    try:
+        kp = PyKeePass(args.database, password=password, keyfile=args.key_file)
+    except CredentialsError:
+        print("Error: invalid credentials for KeePass database", file=sys.stderr)
+        sys.exit(1)
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Search by title; support group/title path (e.g. "Group/Entry")
+    parts = args.entry.rsplit("/", 1)
+    if len(parts) == 2:
+        entries = kp.find_entries(title=parts[1], group=kp.find_groups(name=parts[0], first=True), first=True)
+    else:
+        entries = kp.find_entries(title=args.entry, first=True)
+
+    if entries is None:
+        print(f"Error: entry '{args.entry}' not found in database", file=sys.stderr)
+        sys.exit(1)
+
+    attr = args.attributes
+    value = None
+
+    if attr == "Password":
+        value = entries.password
+    elif attr == "UserName":
+        value = entries.username
+    elif attr == "URL":
+        value = entries.url
+    elif attr == "Notes":
+        value = entries.notes
+    elif attr == "Title":
+        value = entries.title
+    else:
+        # Custom attribute
+        value = entries.custom_properties.get(attr)
+
+    if value is None:
+        print(f"Error: attribute '{attr}' not found on entry '{args.entry}'", file=sys.stderr)
+        sys.exit(1)
+
+    print(value)
+
+
+if __name__ == "__main__":
+    main()
+SHIM
+
+chmod +x /usr/local/bin/keepassxc-cli
+echo "[init-keepassxc-cli] Done. keepassxc-cli shim is ready."

--- a/data/borgscripts/init-keepassxc-cli.sh
+++ b/data/borgscripts/init-keepassxc-cli.sh
@@ -5,56 +5,51 @@
 # no Qt/GUI dependencies) so borgmatic can retrieve credentials from a
 # KeePass database.
 #
-# Usage in borgmatic config:
-#   keepassxc:
-#     keepassxc_cli_command: /usr/local/bin/keepassxc-cli
-#     database: /path/to/passwords.kdbx
-#     ask_for_password: false       # use key_file instead
-#     key_file: /run/secrets/keepass.keyx   # optional
+# Also supports the secret-service backend via secretstorage + jeepney,
+# which connects to the host's D-Bus session bus (mount required — see docs).
 #
-# Then reference credentials in your config:
+# File-based usage:
+#   keepassxc:
+#     database: /path/to/passwords.kdbx
+#     ask_for_password: false
+#     key_file: /run/secrets/keepass.keyx   # optional
 #   encryption_passphrase: "{credential keepassxc /path/to/passwords.kdbx MyEntry}"
+#
+# Secret service usage (requires host D-Bus mount — see KEEPASSXC-CLI.md):
+#   encryption_passphrase: "{credential keepassxc secret-service MyEntry}"
 
 set -e
 
-echo "[init-keepassxc-cli] Installing pykeepass..."
-pip install --quiet --no-cache-dir pykeepass
+echo "[init-keepassxc-cli] Installing pykeepass and secretstorage..."
+pip install --quiet --no-cache-dir pykeepass "secretstorage[jeepney]"
 
 echo "[init-keepassxc-cli] Writing /usr/local/bin/keepassxc-cli shim..."
 cat > /usr/local/bin/keepassxc-cli << 'SHIM'
 #!/usr/bin/env python3
 """
-Minimal keepassxc-cli shim backed by pykeepass.
+Minimal keepassxc-cli shim backed by pykeepass (file-based) and
+secretstorage/jeepney (secret-service backend via host D-Bus).
+
 Implements the subset of keepassxc-cli that borgmatic calls:
-  keepassxc-cli show --show-protected --attributes <attr>
-                     [--no-password] [--key-file <file>]
-                     <database> <entry>
+
+  File-based:
+    keepassxc-cli show --show-protected --attributes <attr>
+                       [--no-password] [--key-file <file>]
+                       <database> <entry>
+
+  Secret service:
+    keepassxc-cli show --secret-service <entry>
 """
 import argparse
 import sys
 
-try:
-    from pykeepass import PyKeePass
-    from pykeepass.exceptions import CredentialsError
-except ImportError:
-    print("pykeepass is not installed", file=sys.stderr)
-    sys.exit(1)
 
-
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("command")                          # 'show'
-    parser.add_argument("--show-protected", action="store_true")
-    parser.add_argument("--attributes", "-a", default="Password")
-    parser.add_argument("--no-password", action="store_true")
-    parser.add_argument("--key-file", "-k", default=None)
-    parser.add_argument("--yubikey", default=None)          # unsupported, accepted silently
-    parser.add_argument("database")
-    parser.add_argument("entry")
-    args = parser.parse_args()
-
-    if args.command != "show":
-        print(f"Unsupported command: {args.command}", file=sys.stderr)
+def lookup_file(args):
+    try:
+        from pykeepass import PyKeePass
+        from pykeepass.exceptions import CredentialsError
+    except ImportError:
+        print("pykeepass is not installed", file=sys.stderr)
         sys.exit(1)
 
     password = None if args.no_password else input("Enter password to unlock database: ")
@@ -68,39 +63,99 @@ def main():
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 
-    # Search by title; support group/title path (e.g. "Group/Entry")
+    # Support group/title path (e.g. "Group/Entry")
     parts = args.entry.rsplit("/", 1)
     if len(parts) == 2:
-        entries = kp.find_entries(title=parts[1], group=kp.find_groups(name=parts[0], first=True), first=True)
+        entry = kp.find_entries(title=parts[1], group=kp.find_groups(name=parts[0], first=True), first=True)
     else:
-        entries = kp.find_entries(title=args.entry, first=True)
+        entry = kp.find_entries(title=args.entry, first=True)
 
-    if entries is None:
+    if entry is None:
         print(f"Error: entry '{args.entry}' not found in database", file=sys.stderr)
         sys.exit(1)
 
     attr = args.attributes
-    value = None
-
     if attr == "Password":
-        value = entries.password
+        value = entry.password
     elif attr == "UserName":
-        value = entries.username
+        value = entry.username
     elif attr == "URL":
-        value = entries.url
+        value = entry.url
     elif attr == "Notes":
-        value = entries.notes
+        value = entry.notes
     elif attr == "Title":
-        value = entries.title
+        value = entry.title
     else:
-        # Custom attribute
-        value = entries.custom_properties.get(attr)
+        value = entry.custom_properties.get(attr)
 
     if value is None:
         print(f"Error: attribute '{attr}' not found on entry '{args.entry}'", file=sys.stderr)
         sys.exit(1)
 
     print(value)
+
+
+def lookup_secret_service(entry_label):
+    try:
+        import secretstorage
+    except ImportError:
+        print("secretstorage is not installed", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        connection = secretstorage.dbus_init()
+    except Exception as e:
+        print(f"Error: could not connect to D-Bus: {e}", file=sys.stderr)
+        print("Ensure the host D-Bus session socket is mounted into the container.", file=sys.stderr)
+        print("See KEEPASSXC-CLI.md for setup instructions.", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        collection = secretstorage.get_default_collection(connection)
+        if collection.is_locked():
+            print("Error: the default secret service collection is locked", file=sys.stderr)
+            sys.exit(1)
+
+        # Search by label first, then fall back to any attribute match
+        items = list(collection.search_items({"label": entry_label}))
+        if not items:
+            # Broader search — some Secret Service providers index differently
+            items = [i for i in collection.get_all_items() if i.get_label() == entry_label]
+
+        if not items:
+            print(f"Error: no secret service item found with label '{entry_label}'", file=sys.stderr)
+            sys.exit(1)
+
+        print(items[0].get_secret().decode())
+    except Exception as e:
+        print(f"Error: secret service lookup failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command")                           # 'show'
+    parser.add_argument("--show-protected", action="store_true")
+    parser.add_argument("--attributes", "-a", default="Password")
+    parser.add_argument("--no-password", action="store_true")
+    parser.add_argument("--key-file", "-k", default=None)
+    parser.add_argument("--secret-service", action="store_true")
+    parser.add_argument("--yubikey", default=None)           # unsupported, accepted silently
+    parser.add_argument("database", nargs="?", default=None) # not used for secret-service
+    parser.add_argument("entry")
+    args = parser.parse_args()
+
+    if args.command != "show":
+        print(f"Unsupported command: {args.command}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.secret_service:
+        lookup_secret_service(args.entry)
+    else:
+        if not args.database:
+            print("Error: database path required for file-based lookup", file=sys.stderr)
+            sys.exit(1)
+        lookup_file(args)
 
 
 if __name__ == "__main__":

--- a/data/borgscripts/init-keepassxc-cli.sh
+++ b/data/borgscripts/init-keepassxc-cli.sh
@@ -5,51 +5,56 @@
 # no Qt/GUI dependencies) so borgmatic can retrieve credentials from a
 # KeePass database.
 #
-# Also supports the secret-service backend via secretstorage + jeepney,
-# which connects to the host's D-Bus session bus (mount required — see docs).
-#
-# File-based usage:
+# Usage in borgmatic config:
 #   keepassxc:
+#     keepassxc_cli_command: /usr/local/bin/keepassxc-cli
 #     database: /path/to/passwords.kdbx
-#     ask_for_password: false
+#     ask_for_password: false       # use key_file instead
 #     key_file: /run/secrets/keepass.keyx   # optional
-#   encryption_passphrase: "{credential keepassxc /path/to/passwords.kdbx MyEntry}"
 #
-# Secret service usage (requires host D-Bus mount — see KEEPASSXC-CLI.md):
-#   encryption_passphrase: "{credential keepassxc secret-service MyEntry}"
+# Then reference credentials in your config:
+#   encryption_passphrase: "{credential keepassxc /path/to/passwords.kdbx MyEntry}"
 
 set -e
 
-echo "[init-keepassxc-cli] Installing pykeepass and secretstorage..."
-pip install --quiet --no-cache-dir pykeepass "secretstorage[jeepney]"
+echo "[init-keepassxc-cli] Installing pykeepass..."
+pip install --quiet --no-cache-dir pykeepass
 
 echo "[init-keepassxc-cli] Writing /usr/local/bin/keepassxc-cli shim..."
 cat > /usr/local/bin/keepassxc-cli << 'SHIM'
 #!/usr/bin/env python3
 """
-Minimal keepassxc-cli shim backed by pykeepass (file-based) and
-secretstorage/jeepney (secret-service backend via host D-Bus).
-
+Minimal keepassxc-cli shim backed by pykeepass.
 Implements the subset of keepassxc-cli that borgmatic calls:
-
-  File-based:
-    keepassxc-cli show --show-protected --attributes <attr>
-                       [--no-password] [--key-file <file>]
-                       <database> <entry>
-
-  Secret service:
-    keepassxc-cli show --secret-service <entry>
+  keepassxc-cli show --show-protected --attributes <attr>
+                     [--no-password] [--key-file <file>]
+                     <database> <entry>
 """
 import argparse
 import sys
 
+try:
+    from pykeepass import PyKeePass
+    from pykeepass.exceptions import CredentialsError
+except ImportError:
+    print("pykeepass is not installed", file=sys.stderr)
+    sys.exit(1)
 
-def lookup_file(args):
-    try:
-        from pykeepass import PyKeePass
-        from pykeepass.exceptions import CredentialsError
-    except ImportError:
-        print("pykeepass is not installed", file=sys.stderr)
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command")                          # 'show'
+    parser.add_argument("--show-protected", action="store_true")
+    parser.add_argument("--attributes", "-a", default="Password")
+    parser.add_argument("--no-password", action="store_true")
+    parser.add_argument("--key-file", "-k", default=None)
+    parser.add_argument("--yubikey", default=None)          # unsupported, accepted silently
+    parser.add_argument("database")
+    parser.add_argument("entry")
+    args = parser.parse_args()
+
+    if args.command != "show":
+        print(f"Unsupported command: {args.command}", file=sys.stderr)
         sys.exit(1)
 
     password = None if args.no_password else input("Enter password to unlock database: ")
@@ -63,7 +68,7 @@ def lookup_file(args):
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 
-    # Support group/title path (e.g. "Group/Entry")
+    # Search by title; support group/title path (e.g. "Group/Entry")
     parts = args.entry.rsplit("/", 1)
     if len(parts) == 2:
         entry = kp.find_entries(title=parts[1], group=kp.find_groups(name=parts[0], first=True), first=True)
@@ -93,69 +98,6 @@ def lookup_file(args):
         sys.exit(1)
 
     print(value)
-
-
-def lookup_secret_service(entry_label):
-    try:
-        import secretstorage
-    except ImportError:
-        print("secretstorage is not installed", file=sys.stderr)
-        sys.exit(1)
-
-    try:
-        connection = secretstorage.dbus_init()
-    except Exception as e:
-        print(f"Error: could not connect to D-Bus: {e}", file=sys.stderr)
-        print("Ensure the host D-Bus session socket is mounted into the container.", file=sys.stderr)
-        print("See KEEPASSXC-CLI.md for setup instructions.", file=sys.stderr)
-        sys.exit(1)
-
-    try:
-        collection = secretstorage.get_default_collection(connection)
-        if collection.is_locked():
-            print("Error: the default secret service collection is locked", file=sys.stderr)
-            sys.exit(1)
-
-        # Search by label first, then fall back to any attribute match
-        items = list(collection.search_items({"label": entry_label}))
-        if not items:
-            # Broader search — some Secret Service providers index differently
-            items = [i for i in collection.get_all_items() if i.get_label() == entry_label]
-
-        if not items:
-            print(f"Error: no secret service item found with label '{entry_label}'", file=sys.stderr)
-            sys.exit(1)
-
-        print(items[0].get_secret().decode())
-    except Exception as e:
-        print(f"Error: secret service lookup failed: {e}", file=sys.stderr)
-        sys.exit(1)
-
-
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("command")                           # 'show'
-    parser.add_argument("--show-protected", action="store_true")
-    parser.add_argument("--attributes", "-a", default="Password")
-    parser.add_argument("--no-password", action="store_true")
-    parser.add_argument("--key-file", "-k", default=None)
-    parser.add_argument("--secret-service", action="store_true")
-    parser.add_argument("--yubikey", default=None)           # unsupported, accepted silently
-    parser.add_argument("database", nargs="?", default=None) # not used for secret-service
-    parser.add_argument("entry")
-    args = parser.parse_args()
-
-    if args.command != "show":
-        print(f"Unsupported command: {args.command}", file=sys.stderr)
-        sys.exit(1)
-
-    if args.secret_service:
-        lookup_secret_service(args.entry)
-    else:
-        if not args.database:
-            print("Error: database path required for file-based lookup", file=sys.stderr)
-            sys.exit(1)
-        lookup_file(args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Ported from borgmatic-collective/docker-borgmatic#489 (open upstream PR, pending review).

## Summary

Adds optional KeePass credential support for use with borgmatic's `{credential keepassxc ...}` syntax.

Alpine's `keepassxc` package pulls in the full Qt6 GUI stack (~150 MB). Rather than baking that into the image for all users, this ships an opt-in init script that users who need KeePass support can mount at startup. Users who don't need it simply don't mount it and get no extra image weight.

### Files added

- `data/borgscripts/init-keepassxc-cli.sh` — custom init script that installs [`pykeepass`](https://github.com/libkeepass/pykeepass) (~2 MB, pure Python, no system deps) and writes a `/usr/local/bin/keepassxc-cli` shim at container startup
- `data/borgscripts/KEEPASSXC-CLI.md` — full setup instructions covering volume mounts, borgmatic config, unattended backup key file usage, and security notes
- README: new KeePassXC section with quick-start example

### How it works

The shim implements the exact CLI interface borgmatic calls:

```
keepassxc-cli show --show-protected --attributes Password [--no-password] [--key-file ...] database.kdbx entry
```

Because it installs to `/usr/local/bin/keepassxc-cli`, borgmatic needs no changes — it calls the same path and gets identical stdout output.

## Test plan

- [ ] CI passes
- [ ] Mount `init-keepassxc-cli.sh` and confirm startup log shows `[init-keepassxc-cli] Done`
- [ ] `docker exec borgmatic keepassxc-cli show --show-protected --attributes Password --no-password db.kdbx entry` returns correct value
- [ ] `borgmatic config validate` passes with a `{credential keepassxc ...}` reference
- [ ] Container without the script mounted starts cleanly with no errors