### PR TITLE
Fix invalid tag format in .woodpecker.yml prepare-tags step

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -18,14 +18,17 @@ steps:
       - hadolint Dockerfile
 
   # Derives image tags from the pinned borgmatic/borg versions in
-  # requirements.txt (e.g. "latest,2.1.6-1.4.4") so published tags track
-  # what's actually in the image, not just a floating "latest".
+  # requirements.txt (e.g. "latest" + "2.1.6-1.4.4") so published tags
+  # track what's actually in the image, not just a floating "latest".
+  # plugin-docker-buildx's tags_file splits strictly on newline, not
+  # comma (unlike thegeeklab/drone-docker-buildx, which this repo's old
+  # .drone.yml worked around by writing a single comma-separated line).
   - name: prepare-tags
     image: alpine
     commands:
       - borgmatic_ver=$(grep 'borgmatic' requirements.txt | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
       - borg_ver=$(grep 'borgbackup' requirements.txt | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
-      - printf "latest,%s-%s" "$borgmatic_ver" "$borg_ver" > .tags
+      - printf "latest\n%s-%s\n" "$borgmatic_ver" "$borg_ver" > .tags
       - echo "Tags to publish:" && cat .tags
 
   - name: build-and-push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2026-07-14 (continued)
+
+### Fixed
+
+- `.woodpecker.yml`: `prepare-tags` now writes newline-separated tags to `.tags` instead of a single comma-separated line. `woodpecker-ci/plugin-docker-buildx`'s `tags_file` splits strictly on `\n` (unlike `thegeeklab/drone-docker-buildx`, which needed the opposite — a single comma-separated line, per the `.drone.yml` fix below from 2026-06-27). The comma-separated form was read as one literal tag (`latest,2.1.6-1.4.4`), which Docker rejected as an invalid reference.
+
 ## 2026-07-14
 
 ### Changed


### PR DESCRIPTION
## Summary
Follow-up to #245. The first Woodpecker build failed with:
```
ERROR: failed to build: invalid tag "*/borgmatic-docker:latest,2.1.6-1.4.4": invalid reference format
```

`woodpecker-ci/plugin-docker-buildx`'s `tags_file` setting splits the file content strictly on `\n` (see [`impl.go`](https://github.com/woodpecker-ci/plugin-docker-buildx/blob/main/plugin/impl.go), `strings.Split(strings.TrimSpace(string(tagsFile)), "\n")`). The `.woodpecker.yml` I wrote in #245 carried over the old `.drone.yml`'s convention of a single comma-separated line (`latest,2.1.6-1.4.4`) — that was specifically a workaround for `thegeeklab/drone-docker-buildx`'s *own* quirk (see the 2026-06-27 CHANGELOG entry), not something Woodpecker's plugin shares. The comma-separated string got read as one literal (invalid) tag.

Fix: write `latest` and `<borgmatic_ver>-<borg_ver>` on separate lines instead.

## Test plan
- [x] Ran the `prepare-tags` shell logic locally in an `alpine` container and confirmed `.tags` now contains newline-separated values (verified via `xxd`).
- [x] Re-validated `.woodpecker.yml` with `woodpecker-cli lint` — still reports `Config is valid`.
- [ ] Confirm the pipeline builds and pushes successfully once merged to `master`.