### PR TITLE
Address keepassxc-cli shim review feedback from upstream #489

### DIFF
--- a/data/borgscripts/KEEPASSXC-CLI.md
+++ b/data/borgscripts/KEEPASSXC-CLI.md
@@ -32,10 +32,10 @@ that it is talking to a Python script instead of the real binary. The
 (`keepassxc-cli`) since the shim is installed at the same path.
 
 Supported flags: `--show-protected`, `--attributes`/`-a`, `--no-password`,
-`--key-file`/`-k`, `--yubikey` (accepted silently — hardware tokens are not
-supported). Attribute lookup covers `Password`, `UserName`, `URL`, `Notes`,
-`Title`, and custom attributes. Group-path style entry names
-(`Group/Entry`) are supported.
+`--key-file`/`-k`. `--yubikey` is rejected with an error — hardware tokens
+are not supported. The only supported attribute is `Password`, matching the
+only attribute borgmatic's KeePassXC hook ever requests; any other value
+errors out. Group-path style entry names (`Group/Entry`) are supported.
 
 ---
 

--- a/data/borgscripts/init-keepassxc-cli.sh
+++ b/data/borgscripts/init-keepassxc-cli.sh
@@ -48,13 +48,21 @@ def main():
     parser.add_argument("--attributes", "-a", default="Password")
     parser.add_argument("--no-password", action="store_true")
     parser.add_argument("--key-file", "-k", default=None)
-    parser.add_argument("--yubikey", default=None)          # unsupported, accepted silently
+    parser.add_argument("--yubikey", default=None)
     parser.add_argument("database")
     parser.add_argument("entry")
     args = parser.parse_args()
 
     if args.command != "show":
         print(f"Unsupported command: {args.command}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.yubikey is not None:
+        print("Unsupported: --yubikey (hardware tokens are not supported)", file=sys.stderr)
+        sys.exit(1)
+
+    if args.attributes != "Password":
+        print(f"Unsupported attribute: {args.attributes} (only 'Password' is supported)", file=sys.stderr)
         sys.exit(1)
 
     password = None if args.no_password else input("Enter password to unlock database: ")
@@ -79,25 +87,11 @@ def main():
         print(f"Error: entry '{args.entry}' not found in database", file=sys.stderr)
         sys.exit(1)
 
-    attr = args.attributes
-    if attr == "Password":
-        value = entry.password
-    elif attr == "UserName":
-        value = entry.username
-    elif attr == "URL":
-        value = entry.url
-    elif attr == "Notes":
-        value = entry.notes
-    elif attr == "Title":
-        value = entry.title
-    else:
-        value = entry.custom_properties.get(attr)
-
-    if value is None:
-        print(f"Error: attribute '{attr}' not found on entry '{args.entry}'", file=sys.stderr)
+    if entry.password is None:
+        print(f"Error: attribute 'Password' not found on entry '{args.entry}'", file=sys.stderr)
         sys.exit(1)
 
-    print(value)
+    print(entry.password)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Mirrors the fix applied upstream in [borgmatic-collective/docker-borgmatic#496](https://github.com/borgmatic-collective/docker-borgmatic/pull/496), which addressed review comments @witten left on upstream #489:

- `--yubikey` is now rejected with an explicit error instead of being accepted silently, matching the existing pattern used for unsupported commands.
- `--attributes` is now restricted to `Password` (the only attribute borgmatic's KeePassXC hook ever requests), erroring on anything else. The `UserName`/`URL`/`Notes`/`Title`/custom-attribute branches are removed since they were unreachable via borgmatic and added surface area with no real use.
- `KEEPASSXC-CLI.md` updated to reflect both of the above.

## Test plan

- [x] `bash -n` on the init script
- [x] `py_compile` on the embedded shim
- [x] Exercised all shim code paths against a real test `.kdbx` (unsupported command, `--yubikey`, unsupported attribute, happy path, entry-not-found)