### PR TITLE
Extend shared renovate-config

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,6 +1,7 @@
 # https://github.com/apps/settings
 # https://github.com/repository-settings/app
 
+_extends: .github
 repository:
   name: docker-borgmatic
   description: >-
@@ -24,36 +25,3 @@ repository:
   allow_update_branch: true
   enable_automated_security_fixes: true
   enable_vulnerability_alerts: true
-
-# Labels: define labels for Issues and Pull Requests
-labels:
-  - name: bug
-    color: d73a4a
-    description: "Something isn't working"
-  - name: dependencies
-    color: C62109
-    description: "Pull requests that update a dependency file"
-  - name: documentation
-    color: "0075ca"
-    description: "Improvements or additions to documentation"
-  - name: duplicate
-    color: cfd3d7
-    description: "This issue or pull request already exists"
-  - name: enhancement
-    color: a2eeef
-    description: "New feature or request"
-  - name: good first issue
-    color: "7057ff"
-    description: "Good for newcomers"
-  - name: help wanted
-    color: "008672"
-    description: "Extra attention is needed"
-  - name: invalid
-    color: e4e669
-    description: "This doesn't seem right"
-  - name: question
-    color: d876e3
-    description: "Further information is requested"
-  - name: wontfix
-    color: ffffff
-    description: "This will not be worked on"

--- a/renovate.json
+++ b/renovate.json
@@ -1,50 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
-  ],
-  "assignees": [
-    "modem7"
-  ],
-  "labels": [
-    "dependencies"
-  ],
-  "timezone": "Europe/London",
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^Dockerfile$/"],
-      "matchStrings": ["ARG S6_OVERLAY_VERSION=(?<currentValue>[0-9.]+)"],
-      "depNameTemplate": "just-containers/s6-overlay",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>.+)$",
-      "versioningTemplate": "loose"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^Dockerfile$/"],
-      "matchStrings": ["ARG ALPINE_VERSION=(?<currentValue>[0-9.]+)"],
-      "depNameTemplate": "alpine",
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "loose"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^Dockerfile$/"],
-      "matchStrings": ["ARG PYTHON_VERSION=(?<currentValue>[0-9.]+)"],
-      "depNameTemplate": "python",
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "loose"
-    }
-  ],
-  "packageRules": [
-    {
-      "matchDepNames": ["alpine"],
-      "allowedVersions": "/^\\d+\\.\\d+$/"
-    },
-    {
-      "matchDepNames": ["python"],
-      "allowedVersions": "/^\\d+\\.\\d+$/"
-    }
+    "github>modem7/renovate-config",
+    "github>modem7/renovate-config:docker"
   ]
 }


### PR DESCRIPTION
## Summary

- Replaces the local `renovate.json` customManagers (S6 overlay, alpine, python ARG version trackers) and packageRules (alpine/python major.minor pinning) with `extends: ["github>modem7/renovate-config", "github>modem7/renovate-config:docker"]` — the shared `:docker` preset covers all of it identically.
- `.github/settings.yml`: adds `_extends: .github` and drops the local `labels:` block, now that `modem7/.github` provides the account-wide default label set for repos that opt in.

Note: this depends on [modem7/renovate-config#6](https://github.com/modem7/renovate-config/pull/6) merging for the new extends target to take full effect. That PR is green on CI but not yet merged — harmless in the meantime since `github>` references resolve against the default branch at evaluation time regardless.

## Test plan

- [x] `npx --yes -p renovate renovate-config-validator` → "Config validated successfully"
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/settings.yml'))"` → parses cleanly